### PR TITLE
Adds link for Facter util

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -3,4 +3,5 @@ Facter/RequireRelative:
   Enabled: true
 Facter/FacterUtil:
   Description: 'Check that facts do not require facter/util/*'
+  StyleGuide: 'https://docs.puppet.com/facter/3.0/release_notes.html#break-removed-ruby-facter-implementations'
   Enabled: true


### PR DESCRIPTION
- If running rubocop with `-S, --display-style-guide        Display style guide URLs in offense messages.` it means you get a link to the page explaining why this has gone
